### PR TITLE
Scheduler decay

### DIFF
--- a/Tribler/Main/tribler_main.py
+++ b/Tribler/Main/tribler_main.py
@@ -446,8 +446,7 @@ class ABCApp(object):
             if self.sconfig.get_enable_multichain():
                 """ Start the multichain community and hook in the multichain scheduler. """
                 multichain = dispersy.define_auto_load(MultiChainCommunity, dispersy_member, load=True,)[0]
-                scheduler = MultiChainScheduler(multichain)
-                self.tunnel_community.multichain_scheduler = scheduler
+                self.tunnel_community.multichain_scheduler = MultiChainScheduler(multichain)
 
             session.set_anon_proxy_settings(2, ("127.0.0.1", session.get_tunnel_community_socks5_listen_ports()))
 

--- a/Tribler/community/multichain/community.py
+++ b/Tribler/community/multichain/community.py
@@ -44,7 +44,7 @@ class MultiChainScheduler:
     threshold = 10 * MEGA_DIVIDER
     
     # Counter decay settings
-    decay_interval = 60.0 
+    decay_interval = 120.0
     decay_factor = 0.95
     decay_threshold = 0.1 * MEGA_DIVIDER
      
@@ -108,16 +108,17 @@ class MultiChainScheduler:
                 "No valid candidate found for: %s:%s to request block from." % (peer[0], peer[1]))
 
     def decay_counters(self):
-        for key in self._outstanding_amount_send:
-            self._outstanding_amount_send[key] *= self.decay_factor
-            if (self._outstanding_amount_send[key] < self.decay_threshold):
-                self._community.logger.warn("Scheduler send counter for peer %s has decayed below the threshold, deleting" % base64.encodestring(key))
-                del self._outstanding_amount_send[key]
-        for key in self._outstanding_amount_received:
-            self._outstanding_amount_received[key] *= self.decay_factor
-            if (self._outstanding_amount_received[key] < self.decay_threshold):
-                self._community.logger.warn("Scheduler received counter for peer %s has decayed below the threshold, deleting" % base64.encodestring(key))
-                del self._outstanding_amount_received[key]
+        def decay_dict(decay):
+            delete_key = []
+            for key in decay:
+                decay[key] *= self.decay_factor
+                if (decay[key] < self.decay_threshold):
+                    self._community.logger.warn("Scheduler counter for peer %s has decayed below the threshold, deleting" % (key,))
+                    delete_key.append(key)
+            for key in delete_key:
+                del decay[key]
+        decay_dict(self._outstanding_amount_send)
+        decay_dict(self._outstanding_amount_received)
 
 class MultiChainCommunity(Community):
     """


### PR DESCRIPTION
Per  @synctext 's request, this change adds counter decay to the multichain scheduler counters. When the counters diverge through clients disconnecting or white washing, they should eventually converge back to 0 to ensure we don't keep an ever expanding state (memory leak). When the counters reach under 10% of the block threshhold they get deleted. The numbers may need adjusting.
