### PR TITLE
Mocking and injection a session to prevent remnants being left behind

### DIFF
--- a/Tribler/Test/test_multichain_community.py
+++ b/Tribler/Test/test_multichain_community.py
@@ -20,6 +20,19 @@ from Tribler.dispersy.tests.debugcommunity.node import DebugNode
 
 
 class TestMultiChainCommunity(DispersyTestFunc):
+    class MockSession():
+        def add_observer(self, func, subject, changeTypes=[], objectID=None, cache=0):
+            pass
+    
+    def setUp(self):
+        super(TestMultiChainCommunity, self).setUp()
+        Session.__single = self.MockSession()
+    
+    def tearDown(self):
+        Session.del_instance()
+        super(TestMultiChainCommunity, self).tearDown()
+        
+    
     """
     Class that tests the MultiChainCommunity on an integration level.
     """


### PR DESCRIPTION
# properEngineering

Ik denk eerlijk gezegd dat dit best een feasible oplossing is, maar het is wel een ding om te beseffen dat de unit-tests nu slagen, wat betekent dat we nergens een unittest hebben die de signing on trigger en what-not test.
